### PR TITLE
Some performance improvements

### DIFF
--- a/util.py
+++ b/util.py
@@ -3,24 +3,22 @@ import torchvision
 import torchvision.transforms.functional as transforms
 from PIL import Image
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-
-def load_styles(style_files, size, scale, oversize):
+def load_styles(style_files, size, scale, oversize, device="cpu", memory_format=torch.contiguous_format):
     styles = []
     for style_file in style_files:
-        styles.append(load_image(style_file, size, scale, not oversize))
+        styles.append(load_image(style_file, size, scale, not oversize, device=device, memory_format=memory_format))
     return styles
 
 
-def maybe_load_content(content_file, size):
+def maybe_load_content(content_file, size, device="cpu", memory_format=torch.contiguous_format):
     content = None
     if content_file is not None:
-        content = load_image(content_file, size, no_quality_loss=False)
+        content = load_image(content_file, size, no_quality_loss=False, device=device, memory_format=memory_format)
     return content
 
 
-def load_image(path, size, scale=1, no_quality_loss=True):
+def load_image(path, size, scale=1, no_quality_loss=True, device="cpu", memory_format=torch.contiguous_format):
     img = Image.open(path).convert(mode="RGB")
 
     size *= scale
@@ -36,11 +34,7 @@ def load_image(path, size, scale=1, no_quality_loss=True):
 
     img = img.resize((int(size), hsize), Image.ANTIALIAS)
 
-    return transforms.to_tensor(img).unsqueeze(0).to(device)
-
-
-def round32(integer):
-    return int(integer + 32 - 1) & -32
+    return transforms.to_tensor(img).unsqueeze(0).to(device, memory_format=memory_format)
 
 
 def save_image(output, args):
@@ -65,3 +59,15 @@ def save_image(output, args):
 
 def name(filepath):
     return filepath.split("/")[-1].split(".")[0]
+
+
+def round32(integer):
+    return int(integer + 32 - 1) & -32
+
+
+def to_nchw(x):
+    return x.permute(0, 3, 1, 2)
+
+
+def to_nhwc(x):
+    return x.permute(0, 2, 3, 1)


### PR DESCRIPTION
Some progress on #4 

- Refactor optimal_textures function into OptimalTextures module (this makes it easier to use PyTorch's JIT and compile APIs)
- Enable batch support
- Update defaults and add some performance related arguments to CLI:
```
  --no_tf32             Disable tf32 format (probably slower).
  --cudnn_benchmark     Enable CUDNN benchmarking (probably slower unless doing a high number of iterations).
  --compile             Use PyTorch 2.0 compile function to optimize the model.
  --script              Use PyTorch JIT script function to optimize the model.
  --device DEVICE       Which device to run on.
  --memory_format {contiguous,channels_last}
                        Which memory format to use for optimization.
```

On my 1080 Ti this version is almost twice as fast for a batch size of 1. Utilization is definitely still low, but upping the batch size helps a lot and I think this is a good springboard for realizing more gains.
